### PR TITLE
Error boundary + magic-link load-failure fallback

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "./context/AuthContext";
 import Layout from "./components/Layout";
+import ErrorBoundary from "./components/ErrorBoundary";
 import HomeLanding from "./pages/HomeLanding";
 import Attendees from "./pages/Attendees";
 import AttendeeMatches from "./pages/AttendeeMatches";
@@ -34,6 +35,7 @@ export default function App() {
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
         <BrowserRouter>
+          <ErrorBoundary>
           <Layout>
             <Routes>
               <Route path="/" element={<HomeLanding />} />
@@ -55,6 +57,7 @@ export default function App() {
               <Route path="*" element={<NotFound />} />
             </Routes>
           </Layout>
+          </ErrorBoundary>
         </BrowserRouter>
       </AuthProvider>
     </QueryClientProvider>

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+interface State {
+  hasError: boolean;
+}
+
+export default class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // Surface in console for debugging; no external logging wired here.
+    console.error("ErrorBoundary caught:", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="min-h-screen flex items-center justify-center px-4 text-center">
+          <div className="max-w-md">
+            <h1 className="text-xl font-semibold text-white mb-2">
+              Something went wrong loading this page
+            </h1>
+            <p className="text-sm text-white/60 mb-6">
+              This is usually a temporary network or browser issue. Please refresh,
+              or try opening the link again. If it keeps happening, contact the
+              Proof of Talk team.
+            </p>
+            <button
+              onClick={() => window.location.reload()}
+              className="rounded-xl px-4 py-2 font-semibold text-white"
+              style={{ background: "#E76315" }}
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/pages/MagicMatches.tsx
+++ b/frontend/src/pages/MagicMatches.tsx
@@ -34,7 +34,7 @@ export default function MagicMatches() {
     }
   }, [searchParams]);
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["magic-matches", token],
     queryFn: () => getMatchesByMagicLink(token!, 10),
     enabled: !!token,
@@ -112,10 +112,23 @@ export default function MagicMatches() {
     return (
       <div className="text-center py-20 space-y-4">
         <Sparkles className="w-8 h-8 text-white/20 mx-auto" />
-        <p className="text-white/40">This link is invalid or has expired.</p>
-        <Link to="/login" className="text-[#E76315] text-sm hover:underline">
-          Log in instead →
-        </Link>
+        <p className="text-white/40">
+          {error ? "We couldn't load this page." : "This link is invalid or has expired."}
+        </p>
+        {error && (
+          <button
+            onClick={() => refetch()}
+            className="px-4 py-2 rounded-xl font-semibold text-white text-sm"
+            style={{ background: "#E76315" }}
+          >
+            Try again
+          </button>
+        )}
+        <div>
+          <Link to="/login" className="text-[#E76315] text-sm hover:underline">
+            {error ? "If you have an account, you can sign in instead →" : "Log in instead →"}
+          </Link>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Defensive fix so a failed page load shows a friendly message instead of a black/blank screen (root cause of "I only get a black screen" reports from unclaimed users opening their magic link).

- **`ErrorBoundary.tsx`** (new) — global React error boundary wrapping all routes; a render crash now shows "Something went wrong loading this page" + Refresh, instead of a black void.
- **`MagicMatches.tsx`** — enhanced the existing error guard: real network/server failures show "We couldn't load this page" + a **Try again** (refetch) button + a sign-in link; invalid/expired-token message preserved.

Note: investigation showed the magic-link page already renders correctly for logged-out + unclaimed users (verified on prod with two real tokens), so this is **defensive hardening**, not a reproduced-bug fix. The reported black screen was environment-specific (browser extension / flaky load); this ensures those cases degrade gracefully.

tsc + vite build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)