### PR TITLE
fix(dashboard): compute Active / Active-7d cards live (no daily-snapshot lag)

### DIFF
--- a/backend/app/api/routes/dashboard.py
+++ b/backend/app/api/routes/dashboard.py
@@ -1010,7 +1010,56 @@ async def get_adoption(
         )
     ).scalar() or 0
 
-    # Usage-by-day history from the snapshot table.
+    # ── Live cumulative_active + active_last_7d ──────────────────────────
+    # Previously read from usage_daily (up to 24 h stale). Now computed live
+    # from users.last_login_at / attendees.last_seen_at so the "Active" cards
+    # on the dashboard are always current.  Same person-dedup + admin/demo
+    # exclusion logic as compute_and_upsert_usage_daily() in usage_snapshot.py.
+    _seven_days_ago = _dt.utcnow() - __import__("datetime").timedelta(days=7)
+
+    _user_rows = (
+        await db.execute(
+            select(User.attendee_id, User.last_login_at).where(
+                User.last_login_at.isnot(None),
+                *_active_user_filter(),
+            )
+        )
+    ).all()
+    _att_rows = (
+        await db.execute(
+            select(Attendee.id, Attendee.last_seen_at).where(
+                Attendee.last_seen_at.isnot(None),
+                *_active_attendee_filter(),
+            )
+        )
+    ).all()
+
+    # Build per-person (attendee_id → latest_ts) map, then count.
+    # Users with no attendee link use an anonymous sentinel keyed on their row.
+    _login_attendee_ids = {r[0] for r in _user_rows if r[0] is not None}
+
+    # Start with every logged-in user (attendee_id or synthetic sentinel).
+    _person_latest: dict = {}
+    for i, (aid, ts) in enumerate(_user_rows):
+        key = aid if aid is not None else ("_user_anon", i)
+        _person_latest[key] = ts
+
+    # Merge attendee rows; if the attendee is already represented by a login,
+    # take the max timestamp rather than adding a second entry.
+    for (aid, seen) in _att_rows:
+        if aid in _login_attendee_ids:
+            if seen and (_person_latest.get(aid) is None or seen > _person_latest[aid]):
+                _person_latest[aid] = seen
+        else:
+            _person_latest[aid] = seen
+
+    cumulative_active = len(_person_latest)
+    active_last_7d = sum(
+        1 for ts in _person_latest.values()
+        if ts is not None and ts >= _seven_days_ago
+    )
+
+    # Usage-by-day history from the snapshot table (trend chart — unchanged).
     usage_rows = (
         await db.execute(
             select(
@@ -1029,13 +1078,8 @@ async def get_adoption(
 
     if usage_by_day:
         tracking_started_at = usage_by_day[0]["day"]
-        latest = usage_by_day[-1]
-        cumulative_active = latest["cumulative_active"]
-        active_last_7d = sum(d["active_today"] for d in usage_by_day[-7:])
     else:
         tracking_started_at = _dt.utcnow().date().isoformat()
-        cumulative_active = 0
-        active_last_7d = 0
 
     return {
         "tracking_started_at": tracking_started_at,

--- a/backend/tests/test_adoption_endpoint.py
+++ b/backend/tests/test_adoption_endpoint.py
@@ -29,8 +29,14 @@ def _make_db():
       5. signups_by_day group-by           -> .all()  [(date, n)]
       6. count(distinct login_active)      -> .scalar()
       7. count(distinct magic_active)      -> .scalar()
-      8. usage_by_day select from usage_daily -> .all() [(day, active_today, cumulative_active)]
+      8. live user rows (attendee_id, last_login_at) -> .all()  [LIVE cumulative/7d]
+      9. live attendee rows (id, last_seen_at)       -> .all()  [LIVE cumulative/7d]
+     10. usage_by_day select from usage_daily        -> .all() [(day, active_today, cumulative_active)]
     """
+    import uuid as _uuid
+    from datetime import datetime as _dt, timedelta as _td
+    _aid = _uuid.uuid4()
+    _recent = _dt.utcnow() - _td(days=1)
     db = AsyncMock()
     db.execute.side_effect = [
         _Scalar(162),                                   # total
@@ -40,6 +46,8 @@ def _make_db():
         _Rows([(date(2026, 5, 21), 46), (date(2026, 5, 22), 50)]),  # signups
         _Scalar(3),                                     # login_active
         _Scalar(7),                                     # magic_link_active
+        _Rows([(_aid, _recent)]),                       # live user rows
+        _Rows([]),                                      # live attendee rows
         _Rows([                                         # usage_by_day
             (date(2026, 5, 24), 4, 9),
         ]),
@@ -65,9 +73,12 @@ async def test_adoption_shape_and_pct_math():
 
     assert out["usage"]["login_active"] == 3
     assert out["usage"]["magic_link_active"] == 7
-    # cumulative_active / active_last_7d derived from usage_by_day (latest row)
-    assert out["usage"]["cumulative_active"] == 9
+    # cumulative_active / active_last_7d are now computed LIVE from user/attendee
+    # rows, not from usage_daily. _make_db feeds 1 live user row → 1 person.
+    assert out["usage"]["cumulative_active"] == 1
+    assert out["usage"]["active_last_7d"] == 1  # the seeded user was recent
 
+    # usage_by_day trend chart still comes from usage_daily (unchanged)
     assert out["usage_by_day"] == [
         {"day": "2026-05-24", "active_today": 4, "cumulative_active": 9},
     ]
@@ -80,7 +91,9 @@ async def test_adoption_empty_usage_falls_back_to_today():
     db.execute.side_effect = [
         _Scalar(0), _Scalar(0), _Scalar(0), _Scalar(0),  # accounts + directory
         _Rows([]),                                         # signups
-        _Scalar(0), _Scalar(0),                            # usage live
+        _Scalar(0), _Scalar(0),                            # login_active / magic_link_active
+        _Rows([]),                                         # live user rows (empty)
+        _Rows([]),                                         # live attendee rows (empty)
         _Rows([]),                                         # usage_by_day EMPTY
     ]
     out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
@@ -88,6 +101,7 @@ async def test_adoption_empty_usage_falls_back_to_today():
     assert out["accounts"]["pct_of_directory"] == 0.0   # no div-by-zero
     assert out["tracking_started_at"] == datetime.utcnow().date().isoformat()
     assert out["usage"]["cumulative_active"] == 0
+    assert out["usage"]["active_last_7d"] == 0
 
 
 def test_adoption_requires_admin_dependency():

--- a/backend/tests/test_adoption_live_active.py
+++ b/backend/tests/test_adoption_live_active.py
@@ -1,0 +1,232 @@
+# backend/tests/test_adoption_live_active.py
+"""GET /dashboard/adoption — cumulative_active and active_last_7d are now
+computed LIVE from users.last_login_at / attendees.last_seen_at, with:
+  - person-level dedup (a user linked to an attendee counts once)
+  - admin + demo exclusion (mirrors the snapshot's _active_*_filter helpers)
+  - active_last_7d = distinct people whose max(last_login_at, last_seen_at) >= now-7d
+
+These two fields must NOT be sourced from usage_daily any more.
+"""
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import app.api.routes.dashboard as dash
+
+
+class _Scalar:
+    def __init__(self, v):
+        self._v = v
+
+    def scalar(self):
+        return self._v
+
+
+class _Rows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build the db mock matching the new query order:
+#   1. count(users)                              -> .scalar()
+#   2. count(real users)                         -> .scalar()
+#   3. count(users where attendee_id not null)   -> .scalar()
+#   4. count(attendees)                          -> .scalar()
+#   5. signups_by_day group-by                   -> .all()
+#   6. count(login_active)                       -> .scalar()
+#   7. count(magic_link_active)                  -> .scalar()
+#   8. live person rows for cumulative/7d        -> .all()  (NEW — user rows)
+#   9. live attendee rows for cumulative/7d      -> .all()  (NEW — attendee rows)
+#  10. usage_by_day from usage_daily             -> .all()
+# ---------------------------------------------------------------------------
+
+def _make_db_live(
+    *,
+    total=10,
+    real=8,
+    linked=8,
+    directory=100,
+    signups=None,
+    login_active=3,
+    magic_link_active=2,
+    # live person dedup inputs
+    user_rows=None,        # list[(attendee_id_or_None, last_login_at)]
+    attendee_rows=None,    # list[(attendee_id, last_seen_at)]
+    # trend chart (unchanged)
+    usage_by_day_rows=None,
+):
+    signups = signups or []
+    user_rows = user_rows if user_rows is not None else []
+    attendee_rows = attendee_rows if attendee_rows is not None else []
+    usage_by_day_rows = usage_by_day_rows if usage_by_day_rows is not None else []
+
+    db = AsyncMock()
+    db.execute.side_effect = [
+        _Scalar(total),
+        _Scalar(real),
+        _Scalar(linked),
+        _Scalar(directory),
+        _Rows(signups),
+        _Scalar(login_active),
+        _Scalar(magic_link_active),
+        _Rows(user_rows),
+        _Rows(attendee_rows),
+        _Rows(usage_by_day_rows),
+    ]
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cumulative_active_counts_login_only_users():
+    """A user with last_login_at set (no attendee link) counts once."""
+    user_rows = [(None, datetime(2026, 5, 20))]
+    attendee_rows = []
+    db = _make_db_live(user_rows=user_rows, attendee_rows=attendee_rows)
+    out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
+    assert out["usage"]["cumulative_active"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cumulative_active_counts_magic_link_only_attendees():
+    """An attendee with last_seen_at but no user row counts once."""
+    aid = uuid.uuid4()
+    user_rows = []
+    attendee_rows = [(aid, datetime(2026, 5, 20))]
+    db = _make_db_live(user_rows=user_rows, attendee_rows=attendee_rows)
+    out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
+    assert out["usage"]["cumulative_active"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cumulative_active_deduplicates_person_with_both():
+    """A person with both login and magic-link (linked via attendee_id) counts ONCE."""
+    aid = uuid.uuid4()
+    user_rows = [(aid, datetime(2026, 5, 22))]      # login
+    attendee_rows = [(aid, datetime(2026, 5, 21))]  # magic-link open, same person
+    db = _make_db_live(user_rows=user_rows, attendee_rows=attendee_rows)
+    out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
+    assert out["usage"]["cumulative_active"] == 1, (
+        "person with both login + magic-link must be counted once, not twice"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cumulative_active_two_distinct_people():
+    """Two completely separate people (different attendee_ids) count as 2."""
+    aid_a = uuid.uuid4()
+    aid_b = uuid.uuid4()
+    user_rows = [(aid_a, datetime(2026, 5, 22))]
+    attendee_rows = [(aid_b, datetime(2026, 5, 21))]
+    db = _make_db_live(user_rows=user_rows, attendee_rows=attendee_rows)
+    out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
+    assert out["usage"]["cumulative_active"] == 2
+
+
+@pytest.mark.asyncio
+async def test_active_last_7d_includes_recent():
+    """A person active within the last 7 days is counted in active_last_7d."""
+    aid = uuid.uuid4()
+    recent = datetime.utcnow() - timedelta(days=3)
+    user_rows = [(aid, recent)]
+    attendee_rows = []
+    db = _make_db_live(user_rows=user_rows, attendee_rows=attendee_rows)
+    out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
+    assert out["usage"]["active_last_7d"] == 1
+
+
+@pytest.mark.asyncio
+async def test_active_last_7d_excludes_older():
+    """A person whose most-recent activity is older than 7 days is NOT in active_last_7d."""
+    aid = uuid.uuid4()
+    old = datetime.utcnow() - timedelta(days=10)
+    user_rows = [(aid, old)]
+    attendee_rows = []
+    db = _make_db_live(user_rows=user_rows, attendee_rows=attendee_rows)
+    out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
+    assert out["usage"]["cumulative_active"] == 1  # still ever-active
+    assert out["usage"]["active_last_7d"] == 0     # outside 7-day window
+
+
+@pytest.mark.asyncio
+async def test_active_last_7d_uses_max_of_login_and_magic():
+    """For a linked person, use max(last_login_at, last_seen_at) for the 7d window."""
+    aid = uuid.uuid4()
+    # login was 10 days ago, magic-link was 2 days ago → should count in 7d
+    old_login = datetime.utcnow() - timedelta(days=10)
+    recent_magic = datetime.utcnow() - timedelta(days=2)
+    user_rows = [(aid, old_login)]
+    attendee_rows = [(aid, recent_magic)]
+    db = _make_db_live(user_rows=user_rows, attendee_rows=attendee_rows)
+    out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
+    assert out["usage"]["cumulative_active"] == 1
+    assert out["usage"]["active_last_7d"] == 1, (
+        "max(login_at, seen_at) within 7d should qualify person for active_last_7d"
+    )
+
+
+@pytest.mark.asyncio
+async def test_active_last_7d_deduplicates():
+    """A person active in 7d via both login and magic counts once in active_last_7d."""
+    aid = uuid.uuid4()
+    recent = datetime.utcnow() - timedelta(days=1)
+    user_rows = [(aid, recent)]
+    attendee_rows = [(aid, recent)]  # same person, same timeframe
+    db = _make_db_live(user_rows=user_rows, attendee_rows=attendee_rows)
+    out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
+    assert out["usage"]["active_last_7d"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cumulative_active_zero_when_no_activity():
+    """No user/attendee activity → cumulative_active and active_last_7d are 0."""
+    db = _make_db_live(user_rows=[], attendee_rows=[])
+    out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
+    assert out["usage"]["cumulative_active"] == 0
+    assert out["usage"]["active_last_7d"] == 0
+
+
+@pytest.mark.asyncio
+async def test_usage_by_day_still_comes_from_snapshot():
+    """usage_by_day trend chart is still sourced from usage_daily (unchanged)."""
+    usage_rows = [(date(2026, 5, 24), 4, 9)]
+    db = _make_db_live(usage_by_day_rows=usage_rows)
+    out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
+    assert out["usage_by_day"] == [
+        {"day": "2026-05-24", "active_today": 4, "cumulative_active": 9}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_live_active_does_not_affect_usage_by_day():
+    """cumulative_active computed live ≠ cumulative in usage_by_day (different sources)."""
+    aid = uuid.uuid4()
+    user_rows = [(aid, datetime(2026, 5, 23))]
+    usage_rows = [(date(2026, 5, 24), 2, 99)]  # snapshot has stale/different number
+    db = _make_db_live(user_rows=user_rows, usage_by_day_rows=usage_rows)
+    out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
+    # Live count (1) != snapshot's cumulative_active (99) — they're separate
+    assert out["usage"]["cumulative_active"] == 1
+    assert out["usage_by_day"][0]["cumulative_active"] == 99
+
+
+@pytest.mark.asyncio
+async def test_tracking_started_at_still_from_snapshot():
+    """tracking_started_at is still the first day in usage_daily (unchanged)."""
+    usage_rows = [
+        (date(2026, 5, 10), 1, 1),
+        (date(2026, 5, 11), 2, 3),
+    ]
+    db = _make_db_live(usage_by_day_rows=usage_rows)
+    out = await dash.get_adoption(db=db, _admin=SimpleNamespace(is_admin=True))
+    assert out["tracking_started_at"] == "2026-05-10"


### PR DESCRIPTION
## Why
The "Active (since tracking began)" and "Active last 7d" cards on the admin dashboard were sourced from the `usage_daily` snapshot table, which is written once per day by a cron at 03:00 UTC. With ~8 days to the event, operators see counts that are up to 24 h stale — while the sibling "Logged in" and "Magic-link opens" cards are already live. This inconsistency is confusing and fixable.

## What changed
**File:** `backend/app/api/routes/dashboard.py` — `GET /dashboard/adoption`

- `cumulative_active`: now computed live by fetching `(attendee_id, last_login_at)` rows from `users` and `(id, last_seen_at)` rows from `attendees`, then deduplicating on `attendee_id` (a person with both a login and a magic-link open counts once). Same admin/demo exclusion as the snapshot service (`_active_user_filter` / `_active_attendee_filter`).
- `active_last_7d`: same person set, filtered to those whose `max(last_login_at, last_seen_at)` falls within the last 7 days.
- `usage_by_day` (trend chart), `tracking_started_at`, `login_active`, `magic_link_active`, and the `accounts` block are **unchanged**.

No migration, no new env vars, no writes.

## Test plan
- **New:** `tests/test_adoption_live_active.py` — 12 tests covering: login-only users, magic-link-only attendees, dedup of a person with both, two distinct people, 7-day window inclusion/exclusion, max-timestamp logic for linked persons, zero-activity base case, trend-chart still from snapshot, and tracking_started_at still from snapshot.
- **Updated:** `tests/test_adoption_endpoint.py` — `_make_db` extended with 2 extra mock responses for the new live-row queries; assertions for `cumulative_active` and `active_last_7d` updated to reflect live-compute behavior (old values were from the snapshot row, new values come from the seeded user rows).
- Full suite: **262 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)