### PR TITLE
fix(magic-link): reciprocity banner copy — 'want to meet you' instead of 'accepted your interest'

### DIFF
--- a/frontend/src/pages/MagicMatches.tsx
+++ b/frontend/src/pages/MagicMatches.tsx
@@ -255,7 +255,7 @@ export default function MagicMatches() {
               <div className="flex-1 min-w-0">
                 <h3 className="text-base font-semibold text-white">
                   {incomingSummary.count_pending_for_you > 0
-                    ? `${incomingSummary.count_pending_for_you} ${incomingSummary.count_pending_for_you === 1 ? "person" : "people"} accepted your interest`
+                    ? `${incomingSummary.count_pending_for_you} ${incomingSummary.count_pending_for_you === 1 ? "person" : "people"} ${incomingSummary.count_pending_for_you === 1 ? "wants" : "want"} to meet you`
                     : `You have ${incomingSummary.count_accepted_back} mutual ${incomingSummary.count_accepted_back === 1 ? "match" : "matches"} waiting`}
                 </h3>
                 <p className="text-sm text-emerald-200/80 mt-0.5">


### PR DESCRIPTION
## Summary

QA follow-up on PR #13 (Phase 2 reciprocity banner). Shaun caught that "{N} people accepted your interest" leaks an asymmetric reciprocity ("Marc expressed interest, 20 people responded") that the data can't actually support.

**Why the old copy was wrong:**
- Matches are symmetric — both sides see the same card.
- The `matches` schema has NO per-side `accepted_at` column, so we can't tell *when* or *how* (in-app vs magic-link) an accept happened.
- A counterpart's `status_b='accepted'` just means "this person clicked 'I'd like to meet' on a card pairing them with you" — not a response to the viewer expressing interest first.

**Why the new copy works:**
- The existing mid-page requests banner already says "{N} people want to meet you" — this aligns the new top banner with that precedent.
- The data the endpoint returns is real and verified (Marc's 20 are 20 distinct claimed-account users from late May), but the framing should be "they want to meet you" not "they responded to you."

The mutual-only branch ("You have N mutual matches waiting") stays — mutual *is* a two-sided accept, real reciprocity.

Singular/plural verb agreement added: `1 person wants` vs `N people want`.

## Test plan

- [x] `npm run build` clean
- [ ] Smoke after deploy: open Marc's `/m/` link, confirm banner reads "20 people want to meet you. Set a password to message them."

🤖 Generated with [Claude Code](https://claude.com/claude-code)