### PR TITLE
Phase 3 magic-link funnel: Maybe-later microcopy + Concierge gating

### DIFF
--- a/frontend/src/components/chat/ChatWidget.tsx
+++ b/frontend/src/components/chat/ChatWidget.tsx
@@ -1,16 +1,34 @@
 import { useState } from "react";
+import { useLocation } from "react-router-dom";
 import { Brain, X } from "lucide-react";
 import ChatPanel from "./ChatPanel";
+import { useAuth } from "../../hooks/useAuth";
 
 export default function ChatWidget() {
   const [open, setOpen] = useState(false);
+  const location = useLocation();
+  const { isAuthenticated } = useAuth();
+  // Phase 3 of the magic-link conversion funnel: unclaimed visitors on /m/
+  // routes can't actually use the Concierge (it requires a JWT). Instead of
+  // opening a panel that 401s, redirect them to the claim flow via a
+  // CustomEvent that MagicMatches listens for.
+  const isMagicLinkUnclaimed =
+    location.pathname.startsWith("/m/") && !isAuthenticated;
 
   return (
     <>
       {/* Floating button — lifted above the mobile bottom-tab bar so it
           doesn't cover the right-most tab (Sign out / Dashboard). */}
       <button
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => {
+          if (isMagicLinkUnclaimed) {
+            window.dispatchEvent(
+              new CustomEvent("pot:open-magic-claim", { detail: { reason: "concierge" } })
+            );
+            return;
+          }
+          setOpen((v) => !v);
+        }}
         className={`fixed bottom-[calc(env(safe-area-inset-bottom)+5rem)] sm:bottom-6 right-4 sm:right-6 z-50 w-14 h-14 rounded-full shadow-2xl flex items-center justify-center transition-all duration-200 ${
           open
             ? "bg-white/10 border border-white/20 text-white/60 scale-90"

--- a/frontend/src/pages/MagicMatches.tsx
+++ b/frontend/src/pages/MagicMatches.tsx
@@ -36,11 +36,33 @@ export default function MagicMatches() {
   const [claimToggled, setClaimToggled] = useState(false);
   const [claimOpen, setClaimOpen] = useState(searchParams.get("unlock") === "1");
   const claimRef = useRef<HTMLDivElement>(null);
+  // Phase 3 — Maybe-later microcopy (shown for 5s on the FIRST defer of the
+  // visit only) + Concierge-gating reason flag for the claim-panel header.
+  const [deferHintForMatchId, setDeferHintForMatchId] = useState<string | null>(null);
+  const deferHintEverShown = useRef(false);
+  const [claimReason, setClaimReason] = useState<"concierge" | null>(null);
   useEffect(() => {
     if (searchParams.get("unlock") === "1") {
       claimRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   }, [searchParams]);
+
+  // Phase 3 — ChatWidget on /m/ routes dispatches this when a non-claimed
+  // visitor taps the Concierge button. Open the claim panel with the
+  // Concierge-flavoured copy instead of letting the panel 401.
+  useEffect(() => {
+    const handler = () => {
+      setClaimError("");
+      setClaimReason("concierge");
+      setClaimToggled(true);
+      setClaimOpen(true);
+      setTimeout(() => {
+        claimRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      }, 50);
+    };
+    window.addEventListener("pot:open-magic-claim", handler);
+    return () => window.removeEventListener("pot:open-magic-claim", handler);
+  }, []);
 
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["magic-matches", token],
@@ -280,14 +302,18 @@ export default function MagicMatches() {
             <KeyRound className="w-5 h-5 text-[#E76315]" />
             <div className="flex-1">
               <h3 className="font-semibold text-[#E76315]">
-                {pendingAcceptPersonName
-                  ? `Confirm interest in ${pendingAcceptPersonName.split(" ")[0]}`
-                  : "Set your password"}
+                {claimReason === "concierge"
+                  ? "AI Concierge"
+                  : pendingAcceptPersonName
+                    ? `Confirm interest in ${pendingAcceptPersonName.split(" ")[0]}`
+                    : "Set your password"}
               </h3>
               <p className="text-xs text-white/40">
-                {pendingAcceptPersonName
-                  ? `Set a quick password (10 seconds) — we'll save your interest and let ${pendingAcceptPersonName.split(" ")[0]} know.`
-                  : "You already have a profile from your ticket — just choose a password to log in and unlock messaging and the AI Concierge."}
+                {claimReason === "concierge"
+                  ? "Claim your account in 10 seconds to chat with the AI Concierge about your matches."
+                  : pendingAcceptPersonName
+                    ? `Set a quick password (10 seconds) — we'll save your interest and let ${pendingAcceptPersonName.split(" ")[0]} know.`
+                    : "You already have a profile from your ticket — just choose a password to log in and unlock messaging and the AI Concierge."}
               </p>
             </div>
             <span className="text-white/30 text-sm">{claimOpen ? "−" : "+"}</span>
@@ -649,12 +675,52 @@ export default function MagicMatches() {
                       I'd like to meet
                     </button>
                     <button
-                      onClick={() => deferMutation.mutate(match.id)}
+                      onClick={() => {
+                        // Phase 3 — show the "skip them permanently" microcopy
+                        // for 5s on the FIRST defer of the visit only. Gated to
+                        // unclaimed visitors; claimed users already have the
+                        // logged-in Decline tool and don't need the nudge.
+                        if (
+                          !deferHintEverShown.current &&
+                          data?.has_account === false
+                        ) {
+                          deferHintEverShown.current = true;
+                          setDeferHintForMatchId(match.id);
+                          setTimeout(() => {
+                            setDeferHintForMatchId((prev) =>
+                              prev === match.id ? null : prev
+                            );
+                          }, 5000);
+                        }
+                        deferMutation.mutate(match.id);
+                      }}
                       disabled={deferMutation.isPending}
                       className="w-full text-center text-xs text-white/30 hover:text-white/50 transition-colors py-1 disabled:opacity-50"
                     >
                       Maybe later
                     </button>
+                    {deferHintForMatchId === match.id && (
+                      <p className="text-[11px] text-white/40 text-center mt-1 animate-in fade-in">
+                        They'll resurface next session. Want to skip them permanently?{" "}
+                        <button
+                          onClick={() => {
+                            setDeferHintForMatchId(null);
+                            setClaimError("");
+                            setClaimToggled(true);
+                            setClaimOpen(true);
+                            setTimeout(() => {
+                              claimRef.current?.scrollIntoView({
+                                behavior: "smooth",
+                                block: "center",
+                              });
+                            }, 50);
+                          }}
+                          className="underline text-emerald-300 hover:text-emerald-200"
+                        >
+                          Set a password to decline →
+                        </button>
+                      </p>
+                    )}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Phase 3 of the 4-phase magic-link conversion-funnel ship ([plan](docs/superpowers/plans/2026-05-28-magic-link-conversion-funnel.md), Phases 1+2 = #12 #13 #14).

**Maybe-later microcopy** ([MagicMatches.tsx](frontend/src/pages/MagicMatches.tsx)):
- On the FIRST defer of an unclaimed visitor's session, a one-line microcopy renders below the tapped card for 5 seconds:
  > "They'll resurface next session. Want to skip them permanently? Set a password to decline →"
- Underlined link opens the existing claim panel.
- Gated to `has_account === false`; claimed users already have the logged-in Decline tool and don't need the nudge.
- `useRef` guard prevents a second defer from re-showing the hint (no nagging).

**Concierge gating** ([ChatWidget.tsx](frontend/src/components/chat/ChatWidget.tsx) + listener in [MagicMatches.tsx](frontend/src/pages/MagicMatches.tsx)):
- ChatWidget detects `/m/` + unauthenticated and dispatches a `CustomEvent("pot:open-magic-claim")` instead of opening ChatPanel (which would 401).
- MagicMatches listens for the event and opens the claim panel with a NEW "AI Concierge" header variant:
  > "AI Concierge — Claim your account in 10 seconds to chat with the AI Concierge about your matches."
- Claimed users still get the normal Concierge open (unchanged).

## Test plan

Playwright mobile smoke (390x844) on unclaimed Ylli (`Z9rzP8v4...`):

- [x] Tap first card's **Maybe later** → microcopy renders with "Set a password to decline →" CTA
- [x] Tap **Open AI Concierge** floating button → claim panel opens with "AI Concierge" header + Concierge-flavoured subtext (ChatPanel does NOT open, no 401)
- [x] `npm run build` clean

Phase 1 + 2 logic untouched. Living docs follow-up to come in Phase 4 commit.

## Deploy

- No migrations, no env-var changes, all frontend, all reversible.
- Phase 3 of 4 — Phase 4 (match-pool paywall) is the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)