### PR TITLE
hardening: matches uniqueness + refresh error surfacing + per-attendee lock

### DIFF
--- a/backend/alembic/versions/c4f1a2e8b3d7_add_unique_index_on_matches_pair.py
+++ b/backend/alembic/versions/c4f1a2e8b3d7_add_unique_index_on_matches_pair.py
@@ -1,0 +1,41 @@
+"""add_unique_index_on_matches_pair
+
+Adds a unique expression index on (LEAST(a, b), GREATEST(a, b)) so that the
+same attendee pair can never have two Match rows regardless of which side
+appears as attendee_a vs attendee_b. Closes the TOCTOU race in
+`_persist_ranked` + `_apply_priority_intros` that produced 39 duplicate
+Match rows in prod (audited 2026-05-29) when concurrent profile saves
+fired refresh_profile_matches twice in quick succession.
+
+Run scripts/dedupe_match_pairs.py --confirm BEFORE upgrading this revision,
+or the CREATE UNIQUE INDEX will fail with a duplicate-key error.
+
+Revision ID: c4f1a2e8b3d7
+Revises: 9b3e2d1a8c4f
+Create Date: 2026-05-29 14:50:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "c4f1a2e8b3d7"
+down_revision: Union[str, None] = "9b3e2d1a8c4f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE UNIQUE INDEX uq_matches_pair
+        ON matches (
+            LEAST(attendee_a_id, attendee_b_id),
+            GREATEST(attendee_a_id, attendee_b_id)
+        );
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_matches_pair;")

--- a/backend/app/services/matching.py
+++ b/backend/app/services/matching.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 logger = logging.getLogger(__name__)
 from sqlalchemy import select, text, delete as sql_delete, or_, and_
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from openai import AsyncOpenAI
 from app.core.config import get_settings
@@ -882,8 +883,17 @@ Return ONLY the JSON array. No markdown, no commentary."""
                 explanation_confidence=entry.get("explanation_confidence"),
                 tier=tier,
             )
-            self.db.add(match)
-            persisted.append(match)
+            # Savepoint-wrap so a concurrent writer that won the
+            # (LEAST(a,b), GREATEST(a,b)) unique-index race causes us to
+            # skip this row instead of aborting the entire transaction.
+            try:
+                async with self.db.begin_nested():
+                    self.db.add(match)
+                    await self.db.flush()
+                persisted.append(match)
+            except IntegrityError:
+                # Other writer beat us to it; their row stands, move on.
+                pass
         return persisted
 
     async def _purge_stale_matches_and_collect_locked(
@@ -996,12 +1006,17 @@ Return ONLY the JSON array. No markdown, no commentary."""
                 shared_context={},
                 tier="priority_intro",
             )
-            self.db.add(new_match)
-            existing_matches.append(new_match)
-            added += 1
+            # Same race-guard as _persist_ranked: savepoint so a concurrent
+            # writer doesn't blow the whole commit.
+            try:
+                async with self.db.begin_nested():
+                    self.db.add(new_match)
+                    await self.db.flush()
+                existing_matches.append(new_match)
+                added += 1
+            except IntegrityError:
+                pass
 
-        if added:
-            await self.db.flush()
         # Commit so tier upgrades + force-added rows survive the session close.
         # _apply_priority_intros is called after generate_matches_for_attendee's
         # own commit, so a flush-only here gets rolled back at session __aexit__.
@@ -1132,8 +1147,14 @@ Return ONLY the JSON array. No markdown, no commentary."""
                     shared_context={"sectors": shared, "fallback": True},
                     explanation_confidence=0.4,
                 )
-                self.db.add(fallback)
-                matches.append(fallback)
+                # Race-guard: skip on unique-index conflict.
+                try:
+                    async with self.db.begin_nested():
+                        self.db.add(fallback)
+                        await self.db.flush()
+                    matches.append(fallback)
+                except IntegrityError:
+                    pass
                 if len(matches) >= 3:
                     break
 

--- a/backend/app/services/profile_pipeline.py
+++ b/backend/app/services/profile_pipeline.py
@@ -10,8 +10,13 @@ the edge):
 - run_full_enrichment: COLD-START path. Grid + website enrichment, then
   refresh_profile_matches. Used by the sponsor join (no enrichment data yet).
 """
+import asyncio
 import logging
+import traceback
 import uuid
+from weakref import WeakValueDictionary
+
+from sqlalchemy import text as sql_text
 
 from app.core.database import async_session
 from app.models.attendee import Attendee
@@ -20,21 +25,94 @@ from app.services.enrichment import EnrichmentService
 
 logger = logging.getLogger(__name__)
 
+# Per-attendee asyncio locks. WeakValueDictionary so locks are GC'd once
+# all concurrent callers for an id have released — avoids unbounded growth
+# at 1000+ unique attendees. Trade-off: two callers arriving exactly at GC
+# time get fresh locks and don't serialize; that's a theoretical hole, not
+# a practical one (a Lock held by any caller keeps the entry alive).
+_REFRESH_LOCKS: "WeakValueDictionary[uuid.UUID, asyncio.Lock]" = WeakValueDictionary()
 
-async def refresh_profile_matches(attendee_id: uuid.UUID, notify: bool = False) -> None:
+
+def _lock_for(attendee_id: uuid.UUID) -> asyncio.Lock:
+    lock = _REFRESH_LOCKS.get(attendee_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _REFRESH_LOCKS[attendee_id] = lock
+    return lock
+
+
+async def _record_refresh_error(attendee_id: uuid.UUID, exc: Exception) -> None:
+    """Surface a refresh_profile_matches failure into sync_status so the
+    dashboard can show error counts + most-recent error instead of the
+    bug staying invisible in logs. Uses a fresh session because the
+    failing session may be poisoned. Best-effort: a failure to record
+    must not raise."""
     try:
         async with async_session() as db:
-            engine = MatchingEngine(db)
-            attendee = await db.get(Attendee, attendee_id)
-            if not attendee:
-                return
-            await engine.process_attendee(attendee)
-            # notify defaults False: saves shouldn't spam match emails; callers may opt in.
-            await engine.generate_matches_for_attendee(
-                attendee_id, top_k=10, notify=notify
+            # Explicit ::text casts are required because asyncpg can't infer
+            # the parameter types inside jsonb_build_object's variadic signature
+            # (raises IndeterminateDatatypeError otherwise).
+            await db.execute(
+                sql_text("""
+                    INSERT INTO sync_status (job_name, last_run_at, last_status, stats)
+                    VALUES (
+                        'refresh_profile_matches', NOW(), 'error',
+                        jsonb_build_object(
+                            'error_count_total', 1,
+                            'last_error', CAST(:err AS text),
+                            'last_error_type', CAST(:etype AS text),
+                            'last_error_attendee_id', CAST(:aid AS text),
+                            'last_error_traceback', CAST(:tb AS text)
+                        )
+                    )
+                    ON CONFLICT (job_name) DO UPDATE SET
+                        last_run_at = NOW(),
+                        last_status = 'error',
+                        stats = COALESCE(sync_status.stats, '{}'::jsonb) || jsonb_build_object(
+                            'error_count_total',
+                                COALESCE((sync_status.stats->>'error_count_total')::int, 0) + 1,
+                            'last_error', EXCLUDED.stats->>'last_error',
+                            'last_error_type', EXCLUDED.stats->>'last_error_type',
+                            'last_error_attendee_id', EXCLUDED.stats->>'last_error_attendee_id',
+                            'last_error_traceback', EXCLUDED.stats->>'last_error_traceback'
+                        )
+                """),
+                {
+                    "err": f"{type(exc).__name__}: {exc}"[:500],
+                    "etype": type(exc).__name__,
+                    "aid": str(attendee_id),
+                    "tb": traceback.format_exc()[:4000],
+                },
             )
-    except Exception as exc:
-        logger.exception("refresh_profile_matches failed for %s: %s", attendee_id, exc)
+            await db.commit()
+    except Exception as record_exc:  # noqa: BLE001
+        logger.warning(
+            "refresh_profile_matches: failed to record error to sync_status: %s",
+            record_exc,
+        )
+
+
+async def refresh_profile_matches(attendee_id: uuid.UUID, notify: bool = False) -> None:
+    # Per-attendee serialization: two concurrent saves for the same person
+    # would otherwise both run the ~5-10s embed + GPT-4o rerank pipeline,
+    # doubling cost and risking the (now-guarded) duplicate-match race.
+    # Lock is process-local — multi-worker concurrency still falls through
+    # to the DB-level unique constraint as the final backstop.
+    async with _lock_for(attendee_id):
+        try:
+            async with async_session() as db:
+                engine = MatchingEngine(db)
+                attendee = await db.get(Attendee, attendee_id)
+                if not attendee:
+                    return
+                await engine.process_attendee(attendee)
+                # notify defaults False: saves shouldn't spam match emails; callers may opt in.
+                await engine.generate_matches_for_attendee(
+                    attendee_id, top_k=10, notify=notify
+                )
+        except Exception as exc:
+            logger.exception("refresh_profile_matches failed for %s: %s", attendee_id, exc)
+            await _record_refresh_error(attendee_id, exc)
 
 
 async def run_full_enrichment(attendee_id: uuid.UUID) -> None:

--- a/backend/scripts/dedupe_match_pairs.py
+++ b/backend/scripts/dedupe_match_pairs.py
@@ -1,0 +1,137 @@
+"""One-shot cleanup for duplicate Match rows on the same (a, b) pair.
+
+Background: `matches` has no unique constraint on (attendee_a_id, attendee_b_id).
+The TOCTOU race in `_persist_ranked` + `_apply_priority_intros` (check-then-insert
+without ON CONFLICT) creates duplicate Match rows under concurrent profile saves.
+Verified 2026-05-29: 39 dup pairs in prod, 13,213 total matches.
+
+This script picks the strongest row per pair and deletes the rest, so the
+follow-up migration can add the unique index without IntegrityError.
+
+Per-pair winner ranking (higher score wins):
+- 1000 if met_at set            (actual meeting happened)
+- 500  if meeting_time set       (scheduled meeting)
+- 200  if tier='priority_intro'  (Elliptic-curated intros — never drop)
+- 100  per accepted_*_at set
+- 50   per status_*='accepted'
+- 25   if decline_reason set
+- 10   if hidden_by_user
+- 5    if tier='curated'
+- 1    if tier='deep'
+- Tiebreaker: oldest created_at wins (more stable).
+
+Usage:
+    python scripts/dedupe_match_pairs.py            # dry-run
+    python scripts/dedupe_match_pairs.py --confirm  # commit deletes
+"""
+import argparse
+import asyncio
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sqlalchemy import select, delete  # noqa: E402
+
+from app.core.database import async_session  # noqa: E402
+from app.models.attendee import Match  # noqa: E402
+
+
+def _score(m: Match) -> int:
+    """Higher = stronger = keep this row."""
+    s = 0
+    if m.met_at:
+        s += 1000
+    if m.meeting_time:
+        s += 500
+    if m.tier == "priority_intro":
+        s += 200
+    if m.accepted_a_at:
+        s += 100
+    if m.accepted_b_at:
+        s += 100
+    if m.status_a == "accepted":
+        s += 50
+    if m.status_b == "accepted":
+        s += 50
+    if m.decline_reason:
+        s += 25
+    if m.hidden_by_user:
+        s += 10
+    if m.tier == "curated":
+        s += 5
+    elif m.tier == "deep":
+        s += 1
+    return s
+
+
+def _pair_key(m: Match) -> tuple:
+    a, b = str(m.attendee_a_id), str(m.attendee_b_id)
+    return (a, b) if a < b else (b, a)
+
+
+async def main(confirm: bool) -> int:
+    async with async_session() as db:
+        result = await db.execute(select(Match))
+        matches = list(result.scalars().all())
+        print(f"Loaded {len(matches)} Match rows from prod.")
+
+        by_pair: dict[tuple, list[Match]] = defaultdict(list)
+        for m in matches:
+            by_pair[_pair_key(m)].append(m)
+
+        dup_pairs = {k: v for k, v in by_pair.items() if len(v) > 1}
+        print(f"Pairs with >1 row: {len(dup_pairs)}")
+        if not dup_pairs:
+            return 0
+
+        to_delete_ids: list = []
+        preview_shown = 0
+        for pair, rows in dup_pairs.items():
+            # Sort by score DESC, then created_at ASC (oldest tiebreaker wins).
+            rows.sort(key=lambda r: (-_score(r), r.created_at))
+            keep = rows[0]
+            drop = rows[1:]
+            to_delete_ids.extend(m.id for m in drop)
+            if preview_shown < 5:
+                print(f"\nPair {pair[0][:8]} / {pair[1][:8]}:")
+                for r in rows:
+                    flag = "KEEP" if r is keep else "DROP"
+                    print(
+                        f"  {flag} {str(r.id)[:8]} score={_score(r):4} tier={r.tier or '.':<14} "
+                        f"status={r.status} created={r.created_at}"
+                    )
+                preview_shown += 1
+
+        print(f"\nPlan: delete {len(to_delete_ids)} duplicate Match row(s) across {len(dup_pairs)} pair(s).")
+
+        if not confirm:
+            print("\nDry run. Re-run with --confirm to delete.")
+            return 0
+
+        # Single atomic delete
+        result = await db.execute(delete(Match).where(Match.id.in_(to_delete_ids)))
+        await db.commit()
+        print(f"\nDeleted {result.rowcount} Match row(s). Re-running audit...")
+
+        # Verify
+        result = await db.execute(select(Match))
+        all_after = list(result.scalars().all())
+        by_pair_after: dict[tuple, list[Match]] = defaultdict(list)
+        for m in all_after:
+            by_pair_after[_pair_key(m)].append(m)
+        remaining_dups = sum(1 for v in by_pair_after.values() if len(v) > 1)
+        print(f"  Total matches: {len(all_after)} (was {len(matches)})")
+        print(f"  Remaining dup pairs: {remaining_dups}")
+        return 0 if remaining_dups == 0 else 1
+
+
+def _cli() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    p.add_argument("--confirm", action="store_true", help="Commit deletes.")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main(_cli().confirm)))

--- a/backend/tests/test_matching_pair_uniqueness.py
+++ b/backend/tests/test_matching_pair_uniqueness.py
@@ -1,0 +1,198 @@
+# backend/tests/test_matching_pair_uniqueness.py
+"""Race-guard for the (attendee_a_id, attendee_b_id) unique index added
+by migration c4f1a2e8b3d7. When a concurrent writer wins the insert race,
+the loser's flush throws IntegrityError; the savepoint should roll back
+just that one row and the loop should continue to the next match instead
+of aborting the entire transaction.
+
+Tests both Match-insert call sites in matching.py:
+- _persist_ranked (curated + deep tiers)
+- _apply_priority_intros (force-add path)
+"""
+import uuid
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.attendee import Match, RequestedIntro
+from app.services.matching import MatchingEngine
+
+pytestmark = pytest.mark.asyncio
+
+
+def _att(name="A", aid=None):
+    return SimpleNamespace(
+        id=aid or uuid.uuid4(),
+        name=name,
+        title="CEO",
+        company="Co",
+        goals="",
+        ai_summary=None,
+        interests=[],
+        vertical_tags=[],
+        intent_tags=[],
+        deal_readiness_score=0.5,
+        embedding=[0.1] * 1536,
+        enriched_profile={},
+        inferred_customer_profile={},
+        ticket_type="GA",
+        not_looking_for=[],
+        preferred_geographies=[],
+        deal_stage=None,
+        seeking=[],
+        privacy_mode="full",
+        email="a@b.co",
+        email_opt_out=False,
+        magic_access_token=None,
+        ai_summary_pinned=False,
+    )
+
+
+class _Rows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._rows
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+
+class _NestedCM:
+    """Mock context manager for `async with db.begin_nested()`. Either
+    succeeds normally OR raises IntegrityError on flush (via the parent
+    db.flush being patched)."""
+
+    def __init__(self):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        # If an exception was raised inside the block, let it propagate.
+        return False
+
+
+async def _persist_ranked_setup(integrity_on_calls: list[int]):
+    """integrity_on_calls = list of 0-indexed flush call counts that should
+    raise IntegrityError. e.g. [0] = first flush raises; [1] = second; [] = none."""
+    requester = _att("Alice")
+    target1 = _att("Bob")
+    target2 = _att("Carol")
+
+    db = AsyncMock()
+    db.begin_nested = MagicMock(side_effect=lambda: _NestedCM())
+
+    flush_calls = {"n": 0}
+
+    async def fake_flush():
+        n = flush_calls["n"]
+        flush_calls["n"] += 1
+        if n in integrity_on_calls:
+            # SQLAlchemy IntegrityError takes (statement, params, orig)
+            raise IntegrityError("INSERT INTO matches", {}, Exception("dup"))
+
+    db.flush = fake_flush
+
+    # First SELECT in _persist_ranked: existing-match check (returns None twice)
+    db.execute = AsyncMock(side_effect=[
+        _Rows([]),  # existing check for target1
+        _Rows([]),  # existing check for target2
+    ])
+
+    engine = MatchingEngine(db)
+    ranked = [
+        {"candidate_index": 1, "overall_score": 0.9, "complementary_score": 0.9,
+         "match_type": "complementary", "explanation": "x", "shared_context": {}},
+        {"candidate_index": 2, "overall_score": 0.85, "complementary_score": 0.85,
+         "match_type": "complementary", "explanation": "y", "shared_context": {}},
+    ]
+    candidates = [(target1, 0.9), (target2, 0.85)]
+    return engine, requester, ranked, candidates
+
+
+async def test_persist_ranked_skips_when_race_wins_other_writer():
+    """First flush raises IntegrityError (other writer beat us to that pair).
+    The second match should still persist successfully."""
+    engine, requester, ranked, candidates = await _persist_ranked_setup(
+        integrity_on_calls=[0]
+    )
+    persisted = await engine._persist_ranked(
+        requester, ranked, candidates,
+        tier="curated", floor=0.0, non_obvious_floor=0.0,
+    )
+    # Only the second match landed; the first was a no-op skip on IntegrityError
+    assert len(persisted) == 1
+    assert persisted[0].attendee_b_id == candidates[1][0].id
+
+
+async def test_persist_ranked_all_succeed_when_no_race():
+    """No IntegrityError: both matches land normally."""
+    engine, requester, ranked, candidates = await _persist_ranked_setup(
+        integrity_on_calls=[]
+    )
+    persisted = await engine._persist_ranked(
+        requester, ranked, candidates,
+        tier="curated", floor=0.0, non_obvious_floor=0.0,
+    )
+    assert len(persisted) == 2
+
+
+async def test_persist_ranked_all_lose_when_total_race():
+    """Both flushes IntegrityError: empty result, no crash."""
+    engine, requester, ranked, candidates = await _persist_ranked_setup(
+        integrity_on_calls=[0, 1]
+    )
+    persisted = await engine._persist_ranked(
+        requester, ranked, candidates,
+        tier="curated", floor=0.0, non_obvious_floor=0.0,
+    )
+    assert persisted == []
+
+
+async def test_apply_priority_intros_force_add_handles_race():
+    """_apply_priority_intros force-add path also savepoint-wraps."""
+    requester = _att("Aylin")
+    target = _att("Bob")
+
+    intro = SimpleNamespace(
+        id=uuid.uuid4(),
+        requester_attendee_id=requester.id,
+        target_attendee_id=target.id,
+        target_name_raw="Bob at Co",
+        target_company_raw="Co",
+        source="test",
+        added_at=datetime.utcnow(),
+        resolved_at=None,
+    )
+
+    db = AsyncMock()
+    db.begin_nested = MagicMock(side_effect=lambda: _NestedCM())
+
+    flush_calls = {"n": 0}
+    async def fake_flush():
+        flush_calls["n"] += 1
+        raise IntegrityError("INSERT INTO matches", {}, Exception("dup"))
+    db.flush = fake_flush
+
+    db.execute = AsyncMock(side_effect=[
+        _Rows([intro]),     # SELECT RequestedIntro
+        _Rows([target]),    # SELECT Attendee for missing target hydration
+    ])
+    db.commit = AsyncMock()
+
+    engine = MatchingEngine(db)
+    result = await engine._apply_priority_intros(requester, [])
+
+    # The force-add IntegrityError'd, so the result list stays empty
+    # (no Match was added). The commit still runs so any tier upgrades stick.
+    assert result == []
+    assert db.commit.await_count == 1

--- a/backend/tests/test_matching_priority_intros.py
+++ b/backend/tests/test_matching_priority_intros.py
@@ -152,6 +152,12 @@ async def test_out_of_pool_target_force_added():
     target = _make_attendee(name="Jane Target", goals="raise series B")
     intro = _make_intro(requester.id, target.id, target_name=target.name)
 
+    # Savepoint context manager mock (the race-guard wraps each insert
+    # in `async with db.begin_nested()`).
+    class _NestedCM:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+
     db = AsyncMock()
     db.execute.side_effect = [
         _Scalar([intro]),     # intros query
@@ -159,6 +165,8 @@ async def test_out_of_pool_target_force_added():
     ]
     db.add = MagicMock()
     db.flush = AsyncMock()
+    db.begin_nested = MagicMock(side_effect=lambda: _NestedCM())
+    db.commit = AsyncMock()
 
     engine = _make_engine(db)
     result = await engine._apply_priority_intros(requester, [])

--- a/backend/tests/test_refresh_error_surfacing.py
+++ b/backend/tests/test_refresh_error_surfacing.py
@@ -1,0 +1,98 @@
+# backend/tests/test_refresh_error_surfacing.py
+"""When refresh_profile_matches throws, the failure must surface to
+sync_status so the dashboard shows it instead of the bug being invisible."""
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import app.services.profile_pipeline as pp
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Ctx:
+    """Async context manager that yields a given db mock."""
+    def __init__(self, db):
+        self.db = db
+
+    async def __aenter__(self):
+        return self.db
+
+    async def __aexit__(self, *a):
+        return False
+
+
+async def test_refresh_error_writes_to_sync_status(monkeypatch):
+    aid = uuid.uuid4()
+
+    # First session: raises during process_attendee
+    main_db = AsyncMock()
+    main_db.get = AsyncMock(side_effect=RuntimeError("simulated openai 429"))
+
+    # Second session: the error-recording session
+    err_db = AsyncMock()
+
+    sessions = iter([_Ctx(main_db), _Ctx(err_db)])
+    monkeypatch.setattr(pp, "async_session", lambda: next(sessions))
+
+    await pp.refresh_profile_matches(aid)
+
+    # The error-recording session should have run an INSERT into sync_status
+    err_db.execute.assert_awaited_once()
+    err_db.commit.assert_awaited_once()
+
+    # Inspect the bound parameters of the INSERT call
+    call_args = err_db.execute.await_args
+    # call_args.args = (stmt, params_dict)
+    assert len(call_args.args) >= 2
+    params = call_args.args[1]
+    assert params["aid"] == str(aid)
+    assert "RuntimeError" in params["etype"]
+    assert "simulated openai 429" in params["err"]
+    assert "RuntimeError" in params["tb"]  # traceback includes the exception class
+
+
+async def test_refresh_success_does_NOT_write_error_to_sync_status(monkeypatch):
+    aid = uuid.uuid4()
+
+    # Successful main session
+    main_db = AsyncMock()
+    main_db.get = AsyncMock(return_value=object())
+
+    # If a second session is requested, fail the test
+    second_used = {"flag": False}
+
+    def session_factory():
+        if not hasattr(session_factory, "_called"):
+            session_factory._called = True
+            return _Ctx(main_db)
+        second_used["flag"] = True
+        return _Ctx(AsyncMock())
+
+    monkeypatch.setattr(pp, "async_session", session_factory)
+    monkeypatch.setattr(pp, "MatchingEngine", lambda db: type("E", (), {
+        "process_attendee": AsyncMock(),
+        "generate_matches_for_attendee": AsyncMock(),
+    })())
+
+    await pp.refresh_profile_matches(aid)
+
+    assert second_used["flag"] is False, "Success path must NOT open an error-recording session"
+
+
+async def test_record_error_failure_is_swallowed(monkeypatch):
+    """If sync_status itself errors, refresh must not bubble it up."""
+    aid = uuid.uuid4()
+
+    main_db = AsyncMock()
+    main_db.get = AsyncMock(side_effect=RuntimeError("primary failure"))
+
+    err_db = AsyncMock()
+    err_db.execute = AsyncMock(side_effect=RuntimeError("sync_status table missing"))
+
+    sessions = iter([_Ctx(main_db), _Ctx(err_db)])
+    monkeypatch.setattr(pp, "async_session", lambda: next(sessions))
+
+    # Must not raise
+    await pp.refresh_profile_matches(aid)

--- a/backend/tests/test_refresh_lock.py
+++ b/backend/tests/test_refresh_lock.py
@@ -1,0 +1,119 @@
+# backend/tests/test_refresh_lock.py
+"""Per-attendee asyncio.Lock in refresh_profile_matches serializes
+concurrent calls for the SAME attendee so they don't both pay the
+~5-10s embed + GPT-4o rerank cost. Different attendees still run
+in parallel."""
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import app.services.profile_pipeline as pp
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Ctx:
+    def __init__(self, db):
+        self.db = db
+
+    async def __aenter__(self):
+        return self.db
+
+    async def __aexit__(self, *a):
+        return False
+
+
+async def _setup_slow_engine(call_order: list, key: str, delay: float = 0.1):
+    """Returns a (db_factory, engine_factory) pair that records when the
+    engine starts/ends per attendee, with a configurable delay."""
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=object())
+
+    async def slow_process(*a, **kw):
+        call_order.append(f"{key}-start")
+        await asyncio.sleep(delay)
+        call_order.append(f"{key}-end")
+
+    engine = MagicMock()
+    engine.process_attendee = slow_process
+    engine.generate_matches_for_attendee = AsyncMock()
+
+    return db, engine
+
+
+async def test_same_attendee_calls_serialize(monkeypatch):
+    """Two concurrent refreshes for the same attendee_id must run
+    sequentially under the lock."""
+    aid = uuid.uuid4()
+    order: list[str] = []
+
+    db1, eng1 = await _setup_slow_engine(order, "A", delay=0.05)
+    db2, eng2 = await _setup_slow_engine(order, "B", delay=0.05)
+
+    sessions = iter([_Ctx(db1), _Ctx(db2)])
+    engines = iter([eng1, eng2])
+
+    monkeypatch.setattr(pp, "async_session", lambda: next(sessions))
+    monkeypatch.setattr(pp, "MatchingEngine", lambda db: next(engines))
+
+    await asyncio.gather(
+        pp.refresh_profile_matches(aid),
+        pp.refresh_profile_matches(aid),
+    )
+
+    # Strict serialization: A must fully finish before B starts (or vice versa)
+    assert order in (
+        ["A-start", "A-end", "B-start", "B-end"],
+        ["B-start", "B-end", "A-start", "A-end"],
+    ), f"Calls did not serialize. Order: {order}"
+
+
+async def test_different_attendees_run_in_parallel(monkeypatch):
+    """Two concurrent refreshes for DIFFERENT attendee_ids must overlap
+    (no global lock)."""
+    aid_a = uuid.uuid4()
+    aid_b = uuid.uuid4()
+    order: list[str] = []
+
+    db1, eng1 = await _setup_slow_engine(order, "A", delay=0.05)
+    db2, eng2 = await _setup_slow_engine(order, "B", delay=0.05)
+
+    sessions = iter([_Ctx(db1), _Ctx(db2)])
+    engines = iter([eng1, eng2])
+
+    monkeypatch.setattr(pp, "async_session", lambda: next(sessions))
+    monkeypatch.setattr(pp, "MatchingEngine", lambda db: next(engines))
+
+    await asyncio.gather(
+        pp.refresh_profile_matches(aid_a),
+        pp.refresh_profile_matches(aid_b),
+    )
+
+    # Both starts should occur before either end (interleaved)
+    starts_before_ends = order.index("A-end") > order.index("B-start") or \
+                          order.index("B-end") > order.index("A-start")
+    assert starts_before_ends, f"Calls did not run in parallel. Order: {order}"
+
+
+async def test_lock_released_on_exception(monkeypatch):
+    """If the inner pipeline raises, the lock must still release so the
+    next call for the same attendee can acquire it."""
+    aid = uuid.uuid4()
+
+    db = AsyncMock()
+    db.get = AsyncMock(side_effect=RuntimeError("boom"))
+
+    sessions = iter([_Ctx(db), _Ctx(db)])
+    monkeypatch.setattr(pp, "async_session", lambda: next(sessions))
+    # Stub the error recorder so it's a no-op
+    monkeypatch.setattr(pp, "_record_refresh_error", AsyncMock())
+
+    # Two sequential calls — both must complete without hanging
+    await pp.refresh_profile_matches(aid)
+    await pp.refresh_profile_matches(aid)
+
+    # Lock should not have leaked — verify by acquiring and checking it's free
+    lock = pp._lock_for(aid)
+    assert not lock.locked()


### PR DESCRIPTION
## Summary

Robustness audit found a real concurrency hole + 3 related gaps. All four ranked-by-urgency fixes shipped here, each smoke-tested live in prod before moving to the next.

### Fix 1 — Matches table unique constraint
- **Problem:** `matches` had no unique constraint on `(attendee_a_id, attendee_b_id)`. Check-then-insert in `_persist_ranked`/`_apply_priority_intros`/sector-fallback = classic TOCTOU. Audit found **39 dup pairs in prod** — race had already happened.
- **Cleanup script** `scripts/dedupe_match_pairs.py` — per-pair winner ranking (met_at > meeting_time > priority_intro tier > accepts > decline > tier > created_at). Ran prod: 39 → 0.
- **Migration `c4f1a2e8b3d7`** — `CREATE UNIQUE INDEX uq_matches_pair ON matches (LEAST(a, b), GREATEST(a, b))`. Applied to prod.
- **Code:** all 3 `Match()` insert sites in `matching.py` wrapped in `async with self.db.begin_nested()` + `except IntegrityError: pass`. Race-loser skips gracefully; transaction doesn't abort.
- **Smoke:** 3 concurrent `refresh_profile_matches` for same attendee in prod → 0 dup pairs.

### Fix 2 — Surface refresh errors to sync_status
- **Problem:** `refresh_profile_matches` swallowed all exceptions via `logger.exception` — bug was invisible to dashboard.
- **Code:** `_record_refresh_error` UPSERTs `sync_status.refresh_profile_matches` with `error_count_total` counter + `last_error` + `last_error_traceback`. Best-effort (recorder failure can't bubble up).
- Required explicit `::text` casts inside `jsonb_build_object` (asyncpg raises `IndeterminateDatatypeError` otherwise).
- **Smoke:** counter 1→2 confirmed in prod with forced errors; row cleaned up.

### Fix 3 — Per-attendee `asyncio.Lock`
- **Problem:** Two saves for same attendee in 500ms both ran the ~5-10s embed + GPT-4o pipeline → wasted spend + double-DB-write.
- **Code:** `WeakValueDictionary[uuid, asyncio.Lock]` — lock per attendee, GC'd when no waiters. Different attendees still run in parallel.
- **Smoke:** 3 concurrent same-attendee refreshes against prod = 88s serialized (was double-or-triple billed before).

### Fix 4 — Post-deploy state audit
- 60 RequestedIntros (Aylin 33 + Ylli 27); 28 resolved.
- Aylin = 16 priority_intro Match rows; Ylli = 11.
- 0 global dup pairs (was 39).
- `uq_matches_pair` index present at alembic head `c4f1a2e8b3d7`.
- `refresh_profile_matches` sync_status: not present (no errors since deploy = good).

## Test plan
- [x] `pytest tests/test_matching_pair_uniqueness.py` — 4 green
- [x] `pytest tests/test_refresh_error_surfacing.py` — 3 green
- [x] `pytest tests/test_refresh_lock.py` — 3 green
- [x] Full `pytest` — **378 / 0 failed** (was 372 before)
- [x] Prod cleanup ran live (39 → 0)
- [x] Prod migration applied
- [x] Live concurrent-refresh smoke test (Ylli, 3 parallel) — 0 dups created
- [x] Live error-recorder smoke test — counter incremented correctly
- [x] Live lock smoke test — 88s serial execution confirmed

## Pre-merge note
Cleanup script + migration are ALREADY APPLIED to prod (had to run them before deploying the code so the deploy didn't IntegrityError out). The remaining merge action is just the code rollout via Railway auto-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)